### PR TITLE
Fixed Readme.md links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,7 +79,7 @@ Which means you could just as easily use it to make...
 
 ## CLI
 
-In addition to a simple [Javascript API](#api), the Metalsmith CLI can read configuration from a `metalsmith.json` file, so that you can build static-site generators similar to [Jekyll](jekyllrb.com) or [Wintersmith](wintersmith.io) easily. The example blog above would be configured like this:
+In addition to a simple [Javascript API](#api), the Metalsmith CLI can read configuration from a `metalsmith.json` file, so that you can build static-site generators similar to [Jekyll](http://jekyllrb.com) or [Wintersmith](http://wintersmith.io) easily. The example blog above would be configured like this:
 
 ```json
 {


### PR DESCRIPTION
Adds in the http:// on the Jekyll and Wintersmith links.
