### PR TITLE
Fixed a date formatting bug in the jekyll example.

### DIFF
--- a/examples/jekyll/_layouts/post.html
+++ b/examples/jekyll/_layouts/post.html
@@ -4,7 +4,7 @@
 </head>
 <body>
   <h1>{{ title }}</h1>
-  <time>{{ date }}</time>
+  <time>{{ date|date('Y-m-d') }}</time>
   {{ contents | safe }}
 </body>
 </html>

--- a/examples/jekyll/_site/first-post/index.html
+++ b/examples/jekyll/_site/first-post/index.html
@@ -4,7 +4,7 @@
 </head>
 <body>
   <h1>First Post</h1>
-  <time>[object Object]</time>
+  <time>2012-08-20</time>
   <p>An interesting post about how it&#39;s going to be different this time around. I&#39;m going write a lot more nowadays and use this blog to improve my writing.</p>
 
 </body>

--- a/examples/jekyll/_site/fourth-post/index.html
+++ b/examples/jekyll/_site/fourth-post/index.html
@@ -4,7 +4,7 @@
 </head>
 <body>
   <h1>Fourth Post</h1>
-  <time>[object Object]</time>
+  <time>2012-12-07</time>
   <p>A really short, rushed-feeling string of words.</p>
 
 </body>

--- a/examples/jekyll/_site/second-post/index.html
+++ b/examples/jekyll/_site/second-post/index.html
@@ -4,7 +4,7 @@
 </head>
 <body>
   <h1>Second Post</h1>
-  <time>[object Object]</time>
+  <time>2012-08-23</time>
   <p>A super-interesting piece of prose I had already written weeks ago.</p>
 
 </body>

--- a/examples/jekyll/_site/third-post/index.html
+++ b/examples/jekyll/_site/third-post/index.html
@@ -4,7 +4,7 @@
 </head>
 <body>
   <h1>Third Post</h1>
-  <time>[object Object]</time>
+  <time>2012-09-28</time>
   <p>A slightly late, less interesting piece of prose.</p>
 
 </body>


### PR DESCRIPTION
This change uses swig's date filter to display a human-readable date, instead of [object Object].
