### PR TITLE
Example code fails silently due to plugins

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ In Metalsmith, all of the logic is handled by plugins. You simply chain them tog
 
 ```js
 Metalsmith(__dirname)
-  .use(markdown)
+  .use(markdown())
   .use(templates('handlebars'))
   .build();
 ```
@@ -15,8 +15,8 @@ Metalsmith(__dirname)
 
 ```js
 Metalsmith(__dirname)
-  .use(drafts)
-  .use(markdown)
+  .use(drafts())
+  .use(markdown())
   .use(permalinks('posts/:title'))
   .use(templates('handlebars'))
   .build();


### PR DESCRIPTION
Same as https://github.com/segmentio/metalsmith.io/pull/5

If plugins are required and passed in to `#use` without having their constructor called, the metalsmith `#build` method fails silently.

eg:

``` js
var Metalsmith = require('metalsmith')
  , markdown = require('metalsmith-markdown');

Metalsmith(__dirname)
  .use(markdown)
  .build(function(err) {
    console.log('This will never be printed');
  });
```

Is it potentially worth storing a hash of plugin methods registered to be called and then error on `build` if they haven't all been called, signifying one in the `use` chain failed to call `next`?
