### PR TITLE
Added #run method which doesn't write the files to disk

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -126,6 +126,10 @@ Add the given `plugin` function to the middleware stack.
 
 Build with the given settings and call `fn(err, files)`.
 
+#### #run(fn)
+
+Build with the given settings without writing the files to disk and call `fn(err, files)`.
+
 #### #source(path)
 
 Set the relative `path` to the source directory, or get the full one if no `path` is provided. The source directory defaults to `./src`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,23 @@ Metalsmith.prototype.join = function(){
  */
 
 Metalsmith.prototype.build = function(fn){
+  var self = this;
+
+  this.run(function(err, files) {
+    if (err) return fn(err);
+    self.write(files, function(err){
+      fn(err, files);
+    });
+  });
+};
+
+/**
+ * Build with the current settings without writing to disk.
+ *
+ * @param {Function} fn
+ */
+
+Metalsmith.prototype.run = function(fn){
   fn = fn || noop;
   var ware = this.ware;
   var self = this;
@@ -110,9 +127,7 @@ Metalsmith.prototype.build = function(fn){
     if (err) return fn(err);
     ware.run(files, self, function(err){
       if (err) return fn(err);
-      self.write(files, function(err){
-        fn(err, files);
-      });
+      fn(null, files);
     });
   });
 };

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,53 @@ describe('Metalsmith', function(){
     });
   });
 
+  describe('#run', function(){
+    it('should do a basic copy with no plugins', function(done){
+      Metalsmith('test/fixtures/basic')
+        .run(function(err, files){
+          if (err) return done(err);
+          assert.equal('object', typeof files);
+          assert.ok(files['index.md']);
+          assert.ok(files['nested/index.md']);
+          done();
+        });
+    });
+
+    it('should preserve binary files', function(done){
+      Metalsmith('test/fixtures/basic-images')
+        .run(function(err, files){
+          if (err) return done(err);
+          assert.equal('object', typeof files);
+          assert.deepEqual(
+            files['2013-11-25 18.59.52.jpg'].contents,
+            fs.readFileSync('test/fixtures/basic-images/expected/2013-11-25 18.59.52.jpg'));
+          done();
+        });
+    });
+
+    it('should apply a plugin', function(done){
+      Metalsmith('test/fixtures/basic-plugin')
+        .use(function(files, metalsmith, done){
+          Object.keys(files).forEach(function(file){
+            var data = files[file];
+            data.contents = new Buffer(data.title);
+          });
+          done();
+        })
+        .run(function(err, files){
+          if (err) return done(err);
+          assert.equal('object', typeof files);
+          assert.deepEqual(
+            files['one.md'].contents,
+            fs.readFileSync('test/fixtures/basic-plugin/expected/one.md'));
+          assert.deepEqual(
+            files['two.md'].contents,
+            fs.readFileSync('test/fixtures/basic-plugin/expected/two.md'));
+          done();
+        });
+    });
+  });
+
   describe('#build', function(){
     it('should do a basic copy with no plugins', function(done){
       Metalsmith('test/fixtures/basic')


### PR DESCRIPTION
I wanted to be able to execute the pipeline without writing the files to disk. So that I can post-process the files in another in-memory build tool like [gulp](http://gulpjs.com/).
