### PR TITLE
Add symlinks metadata API

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -166,6 +166,20 @@ rm -rf .
 
 would be built with mode ```-rwxrw-r--```, i.e. user-executable. 
 
+#### symlink
+
+Use this to mark a file as a symlink. For example, using this code to add to the
+Metalsmith files object:
+
+```js
+files['posts/post1/images'] = { symlink: 'images' };
+```
+
+would build a symlink, ```build/posts/post1/images```, that points to ```build/images```.
+
+_Nested symlinks aren't currently supported. That is, a symlink cannot currently link
+to another symlink_.
+
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -181,19 +181,41 @@ Metalsmith.prototype.read = function(fn){
 
 Metalsmith.prototype.write = function(files, fn){
   var dest = this.destination();
+  var symlinks = {};
 
   rm(dest, function(err){
     if (err) return fn(err);
-    each(Object.keys(files), write, fn);
+    each(Object.keys(files), write, function(err){
+
+      // process symlinks after regular files
+      // note: nested symlinks may not work!
+      if (err) return fn(err);
+      each(Object.keys(symlinks), write_symlinks, fn);
+    });
   });
 
   function write(file, done){
     var data = files[file];
     var out = path.join(dest, file);
-    return fs.outputFile(out, data.contents, function(err){
-      if (err) done(err);
-      if (!data.mode) return done();
-      fs.chmod(out, data.mode, done);
-    });
+
+    // if `symlink` is defined, save to symlinks object to be processed
+    // after writing the non-link files
+    if (data.symlink) {
+      symlinks[file] = data;
+      return done();
+    } else {
+      return fs.outputFile(out, data.contents, function(err){
+        if (err) done(err);
+        if (!data.mode) return done();
+        fs.chmod(out, data.mode, done);
+      });
+    }
+  }
+
+  function write_symlinks(file, done){
+    var src = path.join(dest, symlinks[file].symlink);
+    var out = path.join(dest, file);
+
+    return fs.symlink(src, out, done);
   }
 };

--- a/test/fixtures/write-symlink/src/file
+++ b/test/fixtures/write-symlink/src/file
@@ -1,0 +1,1 @@
+undefined

--- a/test/index.js
+++ b/test/index.js
@@ -163,6 +163,22 @@ describe('Metalsmith', function(){
         done();
       });
     });
+
+    it('should create a symlink using the option in file metadata', function(done){
+      var m = Metalsmith('test/fixtures/write-symlink');
+      var files = {
+        'file': {},
+        'link': {
+          symlink: 'file'
+        }
+      };
+
+      m.write(files, function(err){
+        var stats = fs.lstatSync('test/fixtures/write-symlink/build/link');
+        assert(stats.isSymbolicLink());
+        done();
+      });
+    });
   });
 
   describe('#run', function(){


### PR DESCRIPTION
Note that the symlinks have to be created after the regular files are written. This is because creating a symlink to a file that doesn't exist may fail.

A result of this is that nested symlinks (foo -> bar -> qux) are a little trickier to implement and have been left unsupported. Circular symlinks probably shouldn't ever be supported.

I'll be working on that symlinks feature for [metalsmith-permalinks](http://github.com/segmentio/metalsmith-permalinks) tomorrow, so we'll get to test this new API with an actual feature.
