### PR TITLE
CLI now tries to require local modules first

### DIFF
--- a/bin/metalsmith
+++ b/bin/metalsmith
@@ -47,9 +47,14 @@ plugins.forEach(function(plugin){
   for (var name in plugin) {
     var opts = plugin[name];
     var fn;
+    var localPath = resolve(process.cwd(), 'node_modules', name); 
 
     try {
-      fn = require(name);
+      if (exists(localPath)) {
+        fn = require(localPath);
+      } else {
+        fn = require(name);
+      }
     } catch (e) {
       fatal('failed to require plugin "' + name + '".');
     }


### PR DESCRIPTION
I wrapped the metalsmith CLI in [node-liftoff](https://github.com/tkellen/node-liftoff). This allows the use of a global metalsmith installation with local `metalsmith.json`s without the need to install all the plugin globally, which is more convenient than the old  `node_module/.bin/metalsmith`. It basically works like gulp.js now, where we load a local version of metalsmith when calling `metalsmith` from the command line. 

(tests didn't stage last time -.-)
