### PR TITLE
Internal support for file watching

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,6 +131,17 @@ Add the given `plugin` function to the middleware stack.
 
 Build with the given settings and call `fn(err, files)`.
 
+#### #watch(config, fn)
+
+Watch for modifications, rebuild with the given settings and call `fn(err, files)`.
+
+`config` accepts the following keys:
+- `patterns` (`String|String[]`): the files you want to watch ([minimatch style](https://github.com/isaacs/minimatch)). Default to all the files in the source directory.
+- `events` (`String|String[]`): the events you want to catch. Can be: `all`, `changed`, `added` and/or `deleted`. Default to `all`.
+- `forever` (`Boolean`): whether to continue if an error occurs during the build. Default to `true`.
+- `debounceDelay` (`Integer`): delay in milliseconds between the time of the first detected modification and the rebuild. Default to `250`.
+- `gazeOptions` (`Object`): option object passed to [Gaze](https://github.com/shama/gaze#properties). Default to an empty object.
+
 #### #source(path)
 
 Set the relative `path` to the source directory, or get the full one if no `path` is provided. The source directory defaults to `./src`.

--- a/bin/metalsmith
+++ b/bin/metalsmith
@@ -1,9 +1,21 @@
 #!/usr/bin/env node
 
 var chalk = require('chalk');
+var commander = require('commander');
 var exists = require('fs').existsSync;
 var Metalsmith = require('..');
 var resolve = require('path').resolve;
+var packageJSON = require('../package.json');
+
+/**
+ * Command line.
+ */
+var program = commander;
+program
+  .version(packageJSON.version)
+  .option('-w, --watch [pattern]', 'Watch for file modifications and re-trigger a build')
+  .parse(process.argv)
+;
 
 /**
  * Config.
@@ -65,13 +77,21 @@ plugins.forEach(function(plugin){
 
 
 /**
- * Build.
+ * Build or Watch
  */
 
 metalsmith.build(function(err){
   if (err) return fatal(err.message);
   log('successfully built to ' + metalsmith.destination());
 });
+
+if (program.watch) {
+  if (program.watch !== 'string') program.watch = json.source + '/**/*';
+  metalsmith.watch({ patterns: program.watch }, function onBuild(err) {
+    if (err) return console.log(err.message);
+    log('successfully built to ' + metalsmith.destination());
+  });
+}
 
 /**
  * Log an error and then exit the process.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,12 @@
 
+var _ = require('underscore');
 var clone = require('clone');
 var defaults = require('defaults');
 var each = require('async').each;
+var EventEmitter = require('events').EventEmitter;
 var front = require('front-matter');
 var fs = require('fs-extra');
+var gaze = require('gaze');
 var Mode = require('stat-mode');
 var noop = function(){};
 var path = require('path');
@@ -128,6 +131,111 @@ Metalsmith.prototype.build = function(fn){
       });
     });
   });
+};
+
+/**
+ * Watch the specified directories and re-trigger the build when files are
+ * added, modified and/or deleted.
+ *
+ * Checkout {@link https://github.com/isaacs/minimatch} for more details on the
+ * matching patterns.
+ *
+ * @param {Object} config Configuration object
+ * @param {String|String[]} config.patterns Patterns to be matched. Default to
+ * every files in the source directory (recursively)
+ * @param {String|String[]} config.events Events to be watched. Can be: 'all',
+ * 'changed', 'added' and/or 'deleted'. Default to 'all'
+ * @param {Boolean} config.forever Whether to continue when an error occured
+ * during the build process. If set to `true`, the process will not stop on an
+ * error. If set to `false`, the process will stop on an error. Default to
+ * `true`
+ * @param {Integer} config.debounceDelay Delay in milliseconds between the time
+ * of the first detected modification and the following build. Default to `250`
+ * (ms)
+ * @param {Object} config.gazeOptions Pass specific options to Gaze. See {@link
+ * https://github.com/shama/gaze#properties}. Default to an empty object
+ * @param {Function} fn Function called after each build. Also called if an
+ * error occurs. Called as `function(err, files, end)`, the `end` parameter is a
+ * callback which once called stops the watching.
+
+ * @return {EventEmitter} The following events will be triggered:
+ *   - 'error': when an error occured
+ *         `function onError(err)`
+ *   - 'ready': when the watcher is fully initialized
+ *         `function onInitialized(end)`
+ *   - 'build': when a modification has been catched and the rebuild is done
+ *     (equivalent of the `fn` parameter)
+ *         `function onBuild(files, end)`
+ *   - 'end': when the watcher is closed and stop watching
+ *
+ * It is possible to not pass the configuration object and give the callback as
+ * the first argument (as to mimic a #build() call).
+ */
+
+Metalsmith.prototype.watch = function(config, fn) {
+  var emitter = new EventEmitter();
+
+  // Allow to omit the config parameter
+  if (typeof config === 'function') {
+    fn = config;
+    config = {};
+  }
+
+  config = config || {};
+  config.patterns = config.patterns || (this._src + '/**/*');
+  config.events = config.events || 'all';
+  if (typeof config.forever !== 'boolean') config.forever = true;
+  if (typeof config.debounceDelay !== 'integer') config.debounceDelay = 250;
+  config.gazeOptions = config.gazeOptions || {};
+  fn = fn || noop;
+  var self = this;
+
+  if (!Array.isArray(config.patterns)) config.patterns = [config.patterns];
+  config.patterns = config.patterns.map(function(pattern) {
+    return self.join(pattern);
+  });
+
+  if (!Array.isArray(config.events)) config.events = [config.events];
+  if (~config.events.indexOf('all')) {
+    config.events = ['changed', 'added', 'deleted'];
+  }
+
+  gaze(config.patterns, config.gazeOptions, function(err, watcher) {
+    // Once called, stop the watcher
+    var end = watcher.close.bind(watcher);
+
+    watcher.on('end', function() {
+      emitter.emit('end');
+    });
+
+    if (err) {
+      emitter.emit('error', err);
+      fn(err);
+      return;
+    }
+
+    emitter.emit('ready', end);
+
+    var onEvent = _.debounce(function(event, filepath) {
+      try {
+        self.build(function(err, files) {
+          if (err) emitter.emit('error', err);
+          else     emitter.emit('build', files, end);
+          fn(err, files, end);
+        });
+      } catch (e) {
+        emitter.emit('error', e);
+        fn(e);
+        if (!config.forever) throw e;
+      }
+    }, config.debounceDelay);
+
+    config.events.forEach(function(event) {
+      watcher.on(event, function(filepath) { onEvent(event, filepath); });
+    });
+  });
+
+  return emitter;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,13 +27,16 @@
     "async": "~0.9.0",
     "chalk": "^0.5.0",
     "clone": "^0.1.11",
+    "commander": "^2.2.0",
     "defaults": "~1.0.0",
     "front-matter": "~0.2.0",
     "fs-extra": "~0.10.0",
+    "gaze": "^0.6.4",
     "is-utf8": "~0.2.0",
     "recursive-readdir": "1.1.2",
     "rimraf": "^2.2.8",
     "stat-mode": "^0.2.0",
+    "underscore": "^1.6.0",
     "ware": "~0.3.0"
   },
   "devDependencies": {

--- a/test/fixtures/watch/expected/index.md
+++ b/test/fixtures/watch/expected/index.md
@@ -1,0 +1,1 @@
+Metalsmith

--- a/test/fixtures/watch/src/index.md
+++ b/test/fixtures/watch/src/index.md
@@ -1,0 +1,1 @@
+Metalsmith

--- a/test/index.js
+++ b/test/index.js
@@ -254,6 +254,35 @@ describe('Metalsmith', function(){
         });
     });
   });
+
+  describe('#watch()', function() {
+
+    beforeEach(function() {
+      rm('test/fixtures/watch/build');
+    });
+
+    it('should watch the source directory by default', function(done) {
+      Metalsmith('test/fixtures/watch')
+        .watch(function onBuild(err, files, end) {
+          if (err) return done(err);
+          equal('test/fixtures/watch/build', 'test/fixtures/watch/expected');
+          end();
+        })
+          .on('error', function onError(err) {
+            done(err);
+          })
+          .on('ready', function onInitialized() {
+            refreshModificationTime('test/fixtures/watch/src/index.md');
+          })
+          .on('build', function onBuild(files, end) {
+            equal('test/fixtures/watch/build', 'test/fixtures/watch/expected');
+          })
+          .on('end', function onEnd() {
+            done();
+          })
+      ;
+    });
+  });
 });
 
 describe('CLI', function(){
@@ -307,3 +336,14 @@ describe('CLI', function(){
     });
   });
 });
+
+/**
+ * Set the modification time of a file as the current time. Useful to retrigger
+ * build. Equivalent of the Unix command: `touch -m <filepath>`.
+ *
+ * @param {String} filepath
+ */
+function refreshModificationTime(filepath) {
+  var content = fs.readFileSync(filepath);
+  fs.writeFileSync(filepath, content);
+}


### PR DESCRIPTION
I really appreciate Metalsmith, but one feature I find is really missing is the possibility to watch files modifications to retrigger a build on-the-fly (without using an external build tool). We already discussed this problem and it appears it is not possible to do it properly in a plugin. This is why I took to the liberty to directly patch the core.

So here is my proposal. Please feel free to discuss, I need feedbacks on it.

Below are some examples of what my patch allows to do.
### API - `Metalsmith#watch`

``` javascript
// Callback
Metalsmith(__dirname)
  .watch(function onBuild(err, files, end) {
    if (err) return console.log(err);
  })
;

// Event Emitter
Metalsmith(__dirname)
  .watch()
    .on('error', function onError(err) {
      console.log(err);
    })
    .on('ready', function onReady() {
    })
    .on('build', function onBuild(files, end) {
    })
    .on('end', function onEnd() {
    })
;
```
### CLI - `metalsmith`

``` bash
$ metalsmith --help
Usage: metalsmith [options]

  Options:

    -h, --help             output usage information
    -V, --version          output the version number
    -w, --watch [pattern]  Watch for file modifications and re-trigger a build
```
