### PR TITLE
Expose the `stats` property in each file metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,7 @@ Metalsmith.prototype.read = function(fn){
         }
 
         file.mode = Mode(stats).toOctal();
+        file.stats = stats;
         files[name] = file;
         done();
       });

--- a/test/fixtures/expose-stat/src/index.md
+++ b/test/fixtures/expose-stat/src/index.md
@@ -1,0 +1,3 @@
+---
+title: expose stat
+---

--- a/test/index.js
+++ b/test/index.js
@@ -128,11 +128,13 @@ describe('Metalsmith', function(){
       var m = Metalsmith('test/fixtures/read');
       m.read(function(err, files){
         if (err) return done(err);
+        var stats = fs.statSync(path.join(__dirname, 'fixtures/read/src/index.md'));
         assert.deepEqual(files, {
           'index.md': {
             title: 'A Title',
             contents: new Buffer('body'),
-            mode: fs.statSync(path.join(__dirname, 'fixtures/read/src/index.md')).mode.toString(8).slice(-4)
+            mode: stats.mode.toString(8).slice(-4),
+            stats: stats
           }
         });
         done();
@@ -143,12 +145,23 @@ describe('Metalsmith', function(){
       var m = Metalsmith('test/fixtures/read-mode');
       m.read(function(err, files){
         if (err) return done(err);
+        var stats = fs.statSync(path.join(__dirname, 'fixtures/read-mode/src/bin'));
         assert.deepEqual(files, {
           'bin': {
             contents: new Buffer('echo test'),
-            mode: fs.statSync(path.join(__dirname, 'fixtures/read-mode/src/bin')).mode.toString(8).slice(-4)
+            mode: stats.mode.toString(8).slice(-4),
+            stats: stats
           }
         });
+        done();
+      });
+    });
+
+    it('should expose the stats property in each file metadata', function(done) {
+      var m = Metalsmith('test/fixtures/expose-stat');
+      m.read(function(err, files) {
+        var indexMd = files['index.md'];
+        assert(indexMd.stats instanceof fs.Stats);
         done();
       });
     });


### PR DESCRIPTION
A `stat(1)` call is made for every single file passed to Metalsmith. The only
field exposed in the metadata was `mode`. This commit exposes the whole stats
object by the `stats` property so that it is quickly accessible without the need
of a new `stat(1)` call.

The `mode` property is left as is so as to avoid compatibility issue, though the
information is now duplicated and is also accessible via `stats.mode`.

See: https://github.com/segmentio/metalsmith.io/pull/39
