### PR TITLE
added typecheck for metadata setter function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,12 @@ Metalsmith.prototype.directory = function(directory){
 
 Metalsmith.prototype.metadata = function(metadata){
   if (!arguments.length) return this._metadata;
-  this._metadata = typeof metadata === 'object' ? clone(metadata) : {};
+
+  if (typeof metadata !== 'object' || metadata instanceof Array || metadata === null) {
+    throw new Error('Incompatible metadata type, expecting object.');
+  }
+
+  this._metadata = clone(metadata);
   return this;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ Metalsmith.prototype.directory = function(directory){
 Metalsmith.prototype.metadata = function(metadata){
   if (!arguments.length) return this._metadata;
 
-  if (typeof metadata !== 'object' || metadata instanceof Array || metadata === null) {
+  if (typeof metadata !== 'object' || Array.isArray(metadata) || metadata === null) {
     throw new Error('Incompatible metadata type, expecting object.');
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ Metalsmith.prototype.directory = function(directory){
 
 Metalsmith.prototype.metadata = function(metadata){
   if (!arguments.length) return this._metadata;
-  this._metadata = clone(metadata);
+  this._metadata = typeof metadata === 'object' ? clone(metadata) : {};
   return this;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -148,6 +148,24 @@ describe('Metalsmith', function(){
       assert.notEqual(m.metadata(), data);
       assert.deepEqual(m.metadata(), data);
     });
+
+    it('should return an object literal when undefined', function(){
+      var m = Metalsmith('test/tmp');
+      m.metadata(undefined);
+      assert(m.metadata(), {});
+    });
+
+    it('should return an object literal when setting non-object', function(){
+      var m = Metalsmith('test/tmp');
+      m.metadata(false);
+      assert(m.metadata(), {});
+
+      m.metadata([]);
+      assert(m.metadata(), {});
+
+      m.metadata('test-string');
+      assert(m.metadata(), {});
+    });
   });
 
   describe('#path', function(){

--- a/test/index.js
+++ b/test/index.js
@@ -149,23 +149,30 @@ describe('Metalsmith', function(){
       assert.deepEqual(m.metadata(), data);
     });
 
-    it('should return an object literal when undefined', function(){
+    it('should throw an error when metadata is not an object', function() {
       var m = Metalsmith('test/tmp');
-      m.metadata(undefined);
-      assert(m.metadata(), {});
+
+      assert.throws(function () {
+        m.metadata(false);
+      }, /Incompatible metadata type, expecting object./);
+
+      assert.throws(function () {
+        m.metadata(undefined);
+      }, /Incompatible metadata type, expecting object./);
+
+      assert.throws(function () {
+        m.metadata('string');
+      }, /Incompatible metadata type, expecting object./);
+
+      assert.throws(function () {
+        m.metadata([]);
+      }, /Incompatible metadata type, expecting object./);
+
+      assert.throws(function () {
+        m.metadata(null);
+      }, /Incompatible metadata type, expecting object./);
     });
 
-    it('should return an object literal when setting non-object', function(){
-      var m = Metalsmith('test/tmp');
-      m.metadata(false);
-      assert(m.metadata(), {});
-
-      m.metadata([]);
-      assert(m.metadata(), {});
-
-      m.metadata('test-string');
-      assert(m.metadata(), {});
-    });
   });
 
   describe('#path', function(){


### PR DESCRIPTION
I ran into an odd scenario when using the grunt-metalsmith plugin that invokes `new Metalsmith()` and assumes the user defines a metadata object literal at the very least since it calls `metalsmith.metadata(options.metadata)` without any checks. I started the think, maybe a simple conditional should be used here to catch this but came to the conclusion this may not be the best solution. Since a few metalsmith plugins, including contrib segmentio plugins, make a call to `metalsmith.metadata()` and expect it to be an object without any conditional checks maybe metalsmith should ensure an object is all that can be set here. Instead of invoking pull requests throughout the number of plugins who function this way I thought it should be fixed at the root. I have also included a few test scenarios to make sure only an object is allowed to be set and an object is always returned. Let me know if I am wrong in thinking this and I can adjust the pull request accordingly. 