### PR TITLE
When failing to read a file say which one.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -202,21 +202,26 @@ Metalsmith.prototype.read = unyield(function*(){
  */
 
 Metalsmith.prototype.readFile = unyield(function*(path){
-  var frontmatter = this.frontmatter();
-  var stats = yield fs.stat(path);
-  var buffer = yield fs.readFile(path);
-  var file = {};
+  try {
+    var frontmatter = this.frontmatter();
+    var stats = yield fs.stat(path);
+    var buffer = yield fs.readFile(path);
+    var file = {};
 
-  if (frontmatter && utf8(buffer)) {
-    var parsed = front(buffer.toString());
-    file = parsed.attributes;
-    file.contents = new Buffer(parsed.body);
-  } else {
-    file.contents = buffer;
+    if (frontmatter && utf8(buffer)) {
+      var parsed = front(buffer.toString());
+      file = parsed.attributes;
+      file.contents = new Buffer(parsed.body);
+    } else {
+      file.contents = buffer;
+    }
+
+    file.mode = Mode(stats).toOctal();
+    file.stats = stats;
+  } catch (e) {
+    e.message = 'Failed to read the file at: ' + path + '\n\n' + e.message;
+    throw e;
   }
-
-  file.mode = Mode(stats).toOctal();
-  file.stats = stats;
   return file;
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -246,8 +246,13 @@ Metalsmith.prototype.write = unyield(function*(files){
  */
 
 Metalsmith.prototype.writeFile = unyield(function*(file, data){
-  var dest = this.destination();
-  var out = path.resolve(dest, file);
-  yield fs.outputFile(out, data.contents);
-  if (data.mode) yield fs.chmod(out, data.mode);
+  try {
+    var dest = this.destination();
+    var out = path.resolve(dest, file);
+    yield fs.outputFile(out, data.contents);
+    if (data.mode) yield fs.chmod(out, data.mode);
+  } catch (e) {
+    e.message = 'Failed to write the file at: ' + file + '\n\n' + e.message;
+    throw e;
+  }
 });


### PR DESCRIPTION
I've run into the problem a couple times when doing mass conversions where a file will have something wrong in the frontmatter and I'll get an error, but don't know which file has the problem.

This ensures that if reading of a file fails you know which file it failed on.