### PR TITLE
Document function param required for `build` post 1.0.0.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,9 @@ In Metalsmith, all of the logic is handled by plugins. You simply chain them tog
 Metalsmith(__dirname)
   .use(markdown())
   .use(templates('handlebars'))
-  .build();
+  .build(function(err) {
+    if (err) throw err;
+  });
 ```
 
 ...but what if you want to get fancier by hiding your unfinished drafts and using custom permalinks? Just add plugins...
@@ -20,7 +22,9 @@ Metalsmith(__dirname)
   .use(markdown())
   .use(permalinks('posts/:title'))
   .use(templates('handlebars'))
-  .build();
+  .build(function(err) {
+    if (err) throw err;
+  });
 ```
 
 ...it's as easy as that!


### PR DESCRIPTION
Makes readme examples work with Metalsmith 1.0.0+ so that new folks aren’t confused by silent build failures.

## Details
Adds the (now required) error handler param to the `build` call. Fixes #92 (also mentioned in #87). Note that if accepted, I suggest the same change be made to the examples on metalsmith.io.