### PR TITLE
Avoid an error in recursive-readdir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,6 +185,9 @@ Metalsmith.prototype.read = unyield(function*(){
   var src = this.source();
   var read = this.readFile.bind(this);
   var paths = yield readdir(src);
+  // Filter out undefined values from recursive-readdir:
+  //    https://github.com/jergason/recursive-readdir/pull/12
+  paths = paths.filter(function(path) { return !!path; });
   var files = yield paths.map(read);
 
   return paths.reduce(function(memo, file, i){


### PR DESCRIPTION
Work around a problem within `recursive-readdir`. https://github.com/jergason/recursive-readdir/pull/12

Without this if there are certain types of symlinks within the source directory you get an undefined in the paths array because recursive-readdir is ignoring it's own error in its recursive callback.