### PR TITLE
Strip BOM from source files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var rm = require('rimraf');
 var thunkify = require('thunkify');
 var unyield = require('unyield');
 var utf8 = require('is-utf8');
+var strip = require('strip-bom');
 var Ware = require('ware');
 
 /**
@@ -216,7 +217,8 @@ Metalsmith.prototype.readFile = unyield(function*(path){
     var file = {};
 
     if (frontmatter && utf8(buffer)) {
-      var parsed = front(buffer.toString());
+      var stripped = strip(buffer);
+      var parsed = front(stripped.toString());
       file = parsed.attributes;
       file.contents = new Buffer(parsed.body);
     } else {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "stat-mode": "^0.2.0",
     "thunkify": "^2.1.2",
     "unyield": "0.0.1",
-    "ware": "^1.2.0"
+    "ware": "^1.2.0",
+    "strip-bom": "^1.0.0"
   },
   "devDependencies": {
     "assert-dir-equal": "~1.0.1",

--- a/test/fixtures/read-frontmatter-bom/src/index.md
+++ b/test/fixtures/read-frontmatter-bom/src/index.md
@@ -1,0 +1,3 @@
+﻿---
+template: thing
+---

--- a/test/index.js
+++ b/test/index.js
@@ -252,6 +252,15 @@ describe('Metalsmith', function(){
         done();
       });
     });
+
+    it ('should parse frontmatter in presence of BOM', function(done){
+      var m = Metalsmith('test/fixtures/read-frontmatter-bom');
+      m.read(function(err, files){
+        if (err) return done(err);
+        assert.equal(files['index.md'].template, 'thing');
+        done();
+      });
+    });
   });
 
   describe('#write', function(){


### PR DESCRIPTION
Some unsavoury text editors (looking at you, Visual Studio) prepend a byte order mark (BOM) at the start of each file. This causes parsing of the frontmatter to fail.

Proposed fix first strips the BOM from any parsed file (...it shouldn't really be there anyway--the UTF8 spec "[permits the BOM, but does not recommend its use][1]").

[1]: http://en.wikipedia.org/wiki/Byte_order_mark