### PR TITLE
Print Stack Trace for Errors

### DIFF
--- a/bin/metalsmith
+++ b/bin/metalsmith
@@ -35,7 +35,7 @@ program.on('--help', function(){
   console.log('    $ metalsmith');
   console.log();
   console.log('    # build from lib/config.json:');
-  console.log('    $ myth --config lib/config.json');
+  console.log('    $ metalsmith --config lib/config.json');
   console.log();
 });
 

--- a/bin/metalsmith
+++ b/bin/metalsmith
@@ -95,19 +95,24 @@ normalize(json.plugins).forEach(function(plugin){
  */
 
 metalsmith.build(function(err){
-  if (err) return fatal(err.message);
+  if (err) return fatal(err.message, err.stack);
   log('successfully built to ' + metalsmith.destination());
 });
 
 /**
  * Log an error and then exit the process.
  *
- * @param {String} message
+ * @param {String} msg
+ * @param {String} [stack]  Optional stack trace to print.
  */
 
-function fatal(msg){
+function fatal(msg, stack){
   console.error();
   console.error(chalk.red('  Metalsmith') + chalk.gray(' · ') + msg);
+  if (stack) {
+    console.error();
+    console.error(chalk.gray(stack));
+  }
   console.error();
   process.exit(1);
 }


### PR DESCRIPTION
 * corrects a typo in the help text ("myth" -> "metalsmith")
 * when an error happens during the build, it will also output the stack trace (in gray)