### PR TITLE
Add support for limiting concurrency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -167,6 +167,10 @@ Set the relative `path` to the source directory, or get the full one if no `path
 
 Set the relative `path` to the destination directory, or get the full one if no `path` is provided. The destination directory defaults to `./build`.
 
+#### #concurrency(max)
+
+Set the maximum number of files to open at once when reading or writing.  Defaults to `Infinity`.  To avoid having too many files open at once (`EMFILE` errors), set the concurrency to something lower than `ulimit -n`.
+
 #### #clean(boolean)
 
 Set whether to remove the destination directory before writing to it, or get the current setting. Defaults to `true`.

--- a/bin/metalsmith
+++ b/bin/metalsmith
@@ -67,6 +67,7 @@ try {
 var metalsmith = new Metalsmith(dir);
 if (json.source) metalsmith.source(json.source);
 if (json.destination) metalsmith.destination(json.destination);
+if (json.concurrency) metalsmith.concurrency(json.concurrency);
 if (json.metadata) metalsmith.metadata(json.metadata);
 if (json.clean != null) metalsmith.clean(json.clean);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ function Metalsmith(directory){
   this.metadata({});
   this.source('src');
   this.destination('build');
+  this.concurrency(Infinity);
   this.clean(true);
   this.frontmatter(true);
 }
@@ -110,6 +111,20 @@ Metalsmith.prototype.destination = function(path){
   if (!arguments.length) return this.path(this._destination);
   assert(is.string(path), 'You must pass a destination path string.');
   this._destination = path;
+  return this;
+};
+
+/**
+ * Get or set the maximum number of files to open at once.
+ *
+ * @param {Number} max
+ * @return {Number or Metalsmith}
+ */
+
+Metalsmith.prototype.concurrency = function(max){
+  if (!arguments.length) return this._concurrency;
+  assert(is.number(max), 'You must pass a number for concurrency.');
+  this._concurrency = max;
   return this;
 };
 
@@ -197,7 +212,16 @@ Metalsmith.prototype.read = unyield(function*(dir){
   dir = dir || this.source();
   var read = this.readFile.bind(this);
   var paths = yield readdir(dir);
-  var files = yield paths.map(read);
+
+  var files = [];
+  var complete = 0;
+  var concurrency = this.concurrency();
+  var batch;
+  while (complete < paths.length) {
+    batch = paths.slice(complete, complete + concurrency);
+    files.push.apply(files, yield batch.map(read));
+    complete += concurrency;
+  }
 
   return paths.reduce(function(memo, file, i){
     file = path.relative(dir, file);
@@ -265,10 +289,18 @@ Metalsmith.prototype.write = unyield(function*(files, dir){
   dir = dir || this.destination();
   var write = this.writeFile.bind(this);
 
-  yield Object.keys(files).map(function(key){
-    var file = path.resolve(dir, key);
-    return write(file, files[key]);
-  });
+  var complete = 0;
+  var keys = Object.keys(files);
+  var concurrency = this.concurrency();
+  var batch;
+  while (complete < keys.length) {
+    batch = keys.slice(complete, complete + concurrency);
+    yield batch.map(function(key){
+      var file = path.resolve(dir, key);
+      return write(file, files[key]);
+    });
+    complete += concurrency;
+  }
 });
 
 /**

--- a/test/fixtures/concurrency/expected/file-0.md
+++ b/test/fixtures/concurrency/expected/file-0.md
@@ -1,0 +1,1 @@
+content 0

--- a/test/fixtures/concurrency/expected/file-1.md
+++ b/test/fixtures/concurrency/expected/file-1.md
@@ -1,0 +1,1 @@
+content 1

--- a/test/fixtures/concurrency/expected/file-2.md
+++ b/test/fixtures/concurrency/expected/file-2.md
@@ -1,0 +1,1 @@
+content 2

--- a/test/fixtures/concurrency/expected/file-3.md
+++ b/test/fixtures/concurrency/expected/file-3.md
@@ -1,0 +1,1 @@
+content 3

--- a/test/fixtures/concurrency/expected/file-4.md
+++ b/test/fixtures/concurrency/expected/file-4.md
@@ -1,0 +1,1 @@
+content 4

--- a/test/fixtures/concurrency/expected/file-5.md
+++ b/test/fixtures/concurrency/expected/file-5.md
@@ -1,0 +1,1 @@
+content 5

--- a/test/fixtures/concurrency/expected/file-6.md
+++ b/test/fixtures/concurrency/expected/file-6.md
@@ -1,0 +1,1 @@
+content 6

--- a/test/fixtures/concurrency/expected/file-7.md
+++ b/test/fixtures/concurrency/expected/file-7.md
@@ -1,0 +1,1 @@
+content 7

--- a/test/fixtures/concurrency/expected/file-8.md
+++ b/test/fixtures/concurrency/expected/file-8.md
@@ -1,0 +1,1 @@
+content 8

--- a/test/fixtures/concurrency/expected/file-9.md
+++ b/test/fixtures/concurrency/expected/file-9.md
@@ -1,0 +1,1 @@
+content 9

--- a/test/fixtures/concurrency/src/file-0.md
+++ b/test/fixtures/concurrency/src/file-0.md
@@ -1,0 +1,1 @@
+content 0

--- a/test/fixtures/concurrency/src/file-1.md
+++ b/test/fixtures/concurrency/src/file-1.md
@@ -1,0 +1,1 @@
+content 1

--- a/test/fixtures/concurrency/src/file-2.md
+++ b/test/fixtures/concurrency/src/file-2.md
@@ -1,0 +1,1 @@
+content 2

--- a/test/fixtures/concurrency/src/file-3.md
+++ b/test/fixtures/concurrency/src/file-3.md
@@ -1,0 +1,1 @@
+content 3

--- a/test/fixtures/concurrency/src/file-4.md
+++ b/test/fixtures/concurrency/src/file-4.md
@@ -1,0 +1,1 @@
+content 4

--- a/test/fixtures/concurrency/src/file-5.md
+++ b/test/fixtures/concurrency/src/file-5.md
@@ -1,0 +1,1 @@
+content 5

--- a/test/fixtures/concurrency/src/file-6.md
+++ b/test/fixtures/concurrency/src/file-6.md
@@ -1,0 +1,1 @@
+content 6

--- a/test/fixtures/concurrency/src/file-7.md
+++ b/test/fixtures/concurrency/src/file-7.md
@@ -1,0 +1,1 @@
+content 7

--- a/test/fixtures/concurrency/src/file-8.md
+++ b/test/fixtures/concurrency/src/file-8.md
@@ -1,0 +1,1 @@
+content 8

--- a/test/fixtures/concurrency/src/file-9.md
+++ b/test/fixtures/concurrency/src/file-9.md
@@ -1,0 +1,1 @@
+content 9

--- a/test/index.js
+++ b/test/index.js
@@ -131,6 +131,25 @@ describe('Metalsmith', function(){
     });
   });
 
+  describe('#concurrency', function(){
+    it('should set a max number for concurrency', function(){
+      var m = Metalsmith('test/tmp');
+      m.concurrency(15);
+      assert.equal(m._concurrency, 15);
+    });
+
+    it('should get the max number for concurrency', function(){
+      var m = Metalsmith('test/tmp');
+      m.concurrency(25);
+      assert.equal(m.concurrency(), 25);
+    });
+
+    it('should be infinitely concurrent by default', function(){
+      var m = Metalsmith('test/tmp');
+      assert.equal(m.concurrency(), Infinity);
+    });
+  });
+
   describe('#clean', function(){
     it('should set the clean option', function(){
       var m = Metalsmith('test/tmp');
@@ -271,6 +290,16 @@ describe('Metalsmith', function(){
         done();
       });
     });
+
+    it('should still read all when concurrency is set', function(done){
+      var m = Metalsmith('test/fixtures/concurrency');
+      m.concurrency(3);
+      m.read(function(err, files){
+        if (err) return done(err);
+        assert.equal(Object.keys(files).length, 10);
+        done();
+      });
+    });
   });
 
   describe('#write', function(){
@@ -309,6 +338,18 @@ describe('Metalsmith', function(){
         var mode = Mode(stats).toOctal();
         assert.equal(mode, '0777');
         done();
+      });
+    });
+
+    it('should write all when concurrency is set', function(done){
+      var m = Metalsmith('test/fixtures/concurrency');
+      m.read(function(err, files){
+        if (err) return done(err);
+        m.write(files, function(err){
+          if (err) return done(err);
+          equal('test/fixtures/concurrency/build', 'test/fixtures/concurrency/expected');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
This adds a `concurrency` method to get/set the maximum number of files that should be opened at once for reading or writing.  By default, concurrency is set to `Infinity`.  To make Metalsmith work when the number of files in the source directory exceeds `ulimit -n` (instead of throwing `EMFILE`, see #65), `concurrency` can be set to some lower value.
