### PR TITLE
Added #ignore Method for Readdir() Ignore Support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -175,6 +175,12 @@ Set the maximum number of files to open at once when reading or writing.  Defaul
 
 Set whether to remove the destination directory before writing to it, or get the current setting. Defaults to `true`.
 
+#### #ignore(path)
+
+Ignore files from being loaded into Metalsmith. `file` can be a string,
+or an array of files. Glob syntax is supported via
+[minimatch](https://github.com/isaacs/minimatch).
+
 #### #metadata(json)
 
 Get the global metadata. This is useful for plugins that want to set global-level metadata that can be applied to all files.

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ function Metalsmith(directory){
   if (!(this instanceof Metalsmith)) return new Metalsmith(directory);
   assert(directory, 'You must pass a working directory path.');
   this.plugins = [];
+  this.ignores = [];
   this.directory(directory);
   this.metadata({});
   this.source('src');
@@ -156,6 +157,18 @@ Metalsmith.prototype.frontmatter = function(frontmatter){
 };
 
 /**
+ * Add a file or files to the list of ignores.
+ *
+ * @param {String or Strings} The names of files or directories to ignore.
+ * @return {Metalsmith}
+ */
+Metalsmith.prototype.ignore = function(files){
+  if (!arguments.length) return this.ignores.slice();
+  this.ignores = this.ignores.concat(files);
+  return this
+}
+
+/**
  * Resolve `paths` relative to the root directory.
  *
  * @param {String} paths...
@@ -212,7 +225,8 @@ Metalsmith.prototype.read = unyield(function*(dir){
   dir = dir || this.source();
   var read = this.readFile.bind(this);
   var concurrency = this.concurrency();
-  var paths = yield readdir(dir);
+  var ignores = this.ignores || null;
+  var paths = yield readdir(dir, ignores);
   var files = [];
   var complete = 0;
   var batch;

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,14 @@ describe('Metalsmith', function(){
     });
   });
 
+  describe('#ignore', function(){
+    it('should add an ignore file to the internal ignores list', function(){
+      var m = Metalsmith('test/tmp');
+      m.ignore('dirfile')
+      assert(1 == m.ignores.length);
+    })
+  })
+
   describe('#directory', function(){
     it('should set a working directory', function(){
       var m = Metalsmith('test/tmp');
@@ -297,6 +305,25 @@ describe('Metalsmith', function(){
       m.read(function(err, files){
         if (err) return done(err);
         assert.equal(Object.keys(files).length, 10);
+        done();
+      });
+    });
+
+    it('should ignore the files specified in ignores', function(done){
+      var m = Metalsmith('test/fixtures/basic');
+      m.ignore('nested');
+      m.read(function(err, files){
+        if (err) return done(err);
+        stats = fs.statSync(path.join(__dirname, 'fixtures/basic/src/index.md'));
+        assert.deepEqual(files, {
+          'index.md': {
+            date: new Date('2013-12-02'),
+            title: 'A Title',
+            contents: new Buffer('body'),
+            mode: stats.mode.toString(8).slice(-4),
+            stats: stats
+          }
+        });
         done();
       });
     });


### PR DESCRIPTION
`ignore('foo')` will ignore the `foo` path from ever being loaded into
Metalsmith by passing the ignore to the `readdir` function.

This level of ignore is useful because in some cases, the memory bloat
from reading all files and then removing them can cause the memory limit
to be exceeded before the read has even finished.

This method solves that by never reading the ignored files to begin with.