### PR TITLE
using a separate _metalsmith bin to allow custom transpilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "iojs"

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@
 # Adds --harmony-generators flag when available/necessary
 #
 
-node_flags ?= $(shell $(NODE) --v8-options | grep generators | cut -d ' ' -f 3)
+node ?= node
+node_flags ?= $(shell $(node) --v8-options | grep generators | cut -d ' ' -f 3)
 
 #
 # Binaries.
 #
 
-mocha = ./node_modules/.bin/mocha
+mocha = $(node) $(node_flags) ./node_modules/.bin/_mocha
 
 #
 # Targets.
@@ -22,11 +23,11 @@ node_modules: package.json
 
 # Run the tests.
 test: node_modules
-	@$(mocha) $(node_flags)
+	@$(mocha)
 
 # Run the tests in debugging mode.
 test-debug: node_modules
-	@$(mocha) $(node_flags) debug
+	@$(mocha) debug
 
 #
 # Phonies.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 
 #
+# Adds --harmony-generators flag when available/necessary
+#
+
+node_flags ?= $(shell $(NODE) --v8-options | grep generators | cut -d ' ' -f 3)
+
+#
 # Binaries.
 #
 
@@ -16,11 +22,11 @@ node_modules: package.json
 
 # Run the tests.
 test: node_modules
-	@$(mocha)
+	@$(mocha) $(node_flags)
 
 # Run the tests in debugging mode.
 test-debug: node_modules
-	@$(mocha) debug
+	@$(mocha) $(node_flags) debug
 
 #
 # Phonies.

--- a/bin/_metalsmith
+++ b/bin/_metalsmith
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+/**
+ * Dependencies.
+ */
+
+var chalk = require('chalk');
+var exists = require('fs').existsSync;
+var Metalsmith = require('..');
+var program = require('commander');
+var resolve = require('path').resolve;
+
+/**
+ * Usage.
+ */
+
+program
+  .version(require('../package.json').version)
+  .option('-c, --config <path>', 'configuration file location', 'metalsmith.json');
+
+/**
+ * Examples.
+ */
+
+program.on('--help', function(){
+  console.log('  Examples:');
+  console.log();
+  console.log('    # build from metalsmith.json:');
+  console.log('    $ metalsmith');
+  console.log();
+  console.log('    # build from lib/config.json:');
+  console.log('    $ metalsmith --config lib/config.json');
+  console.log();
+});
+
+/**
+ * Parse.
+ */
+
+program.parse(process.argv);
+
+/**
+ * Config.
+ */
+
+var dir = process.cwd();
+var config = program.config;
+var path = resolve(dir, config);
+if (!exists(path)) fatal('could not find a ' + config + ' configuration file.');
+
+try {
+  var json = require(path);
+} catch (e) {
+  fatal('it seems like ' + config + ' is malformed.');
+}
+
+/**
+ * Metalsmith.
+ */
+
+var metalsmith = new Metalsmith(dir);
+if (json.source) metalsmith.source(json.source);
+if (json.destination) metalsmith.destination(json.destination);
+if (json.concurrency) metalsmith.concurrency(json.concurrency);
+if (json.metadata) metalsmith.metadata(json.metadata);
+if (json.clean != null) metalsmith.clean(json.clean);
+
+/**
+ * Plugins.
+ */
+
+normalize(json.plugins).forEach(function(plugin){
+  for (var name in plugin) {
+    var opts = plugin[name];
+    var mod;
+
+    try {
+      var local = resolve(dir, name);
+      var npm = resolve(dir, 'node_modules', name);
+
+      if (exists(local) || exists(local + '.js')) {
+        mod = require(local);
+      } else if (exists(npm)) {
+        mod = require(npm);
+      } else {
+        mod = require(name);
+      }
+    } catch (e) {
+      fatal('failed to require plugin "' + name + '".');
+    }
+
+    try {
+      metalsmith.use(mod(opts));
+    } catch (e) {
+      fatal('error using plugin "' + name + '"...', e.message + '\n\n' + e.stack);
+    }
+  }
+});
+
+/**
+ * Build.
+ */
+
+metalsmith.build(function(err){
+  if (err) return fatal(err.message, err.stack);
+  log('successfully built to ' + metalsmith.destination());
+});
+
+/**
+ * Log an error and then exit the process.
+ *
+ * @param {String} msg
+ * @param {String} [stack]  Optional stack trace to print.
+ */
+
+function fatal(msg, stack){
+  console.error();
+  console.error(chalk.red('  Metalsmith') + chalk.gray(' · ') + msg);
+  if (stack) {
+    console.error();
+    console.error(chalk.gray(stack));
+  }
+  console.error();
+  process.exit(1);
+}
+
+/**
+ * Log a `message`.
+ *
+ * @param {String} message
+ */
+
+function log(message){
+  console.log();
+  console.log(chalk.gray('  Metalsmith · ') + message);
+  console.log();
+}
+
+/**
+ * Normalize an `obj` of plugins.
+ *
+ * @param {Array or Object} obj
+ * @return {Array}
+ */
+
+function normalize(obj){
+  if (obj instanceof Array) return obj;
+  var ret = [];
+
+  for (var key in obj) {
+    var plugin = {};
+    plugin[key] = obj[key];
+    ret.push(plugin);
+  }
+
+  return ret;
+}

--- a/bin/metalsmith
+++ b/bin/metalsmith
@@ -1,163 +1,40 @@
 #!/usr/bin/env node
 
 /**
- * Add backwards compatibility for Node 0.10.
+ * Module dependencies.
  */
 
-require('gnode');
-
-/**
- * Dependencies.
- */
-
-var chalk = require('chalk');
-var exists = require('fs').existsSync;
-var Metalsmith = require('..');
-var program = require('commander');
+var spawn = require('win-fork');
 var resolve = require('path').resolve;
 
 /**
- * Usage.
+ * Resolve.
  */
 
-program
-  .version(require('../package.json').version)
-  .option('-c, --config <path>', 'configuration file location', 'metalsmith.json');
+var args = process.argv.slice(2);
 
 /**
- * Examples.
+ * If we're not talking about a sub-command, fall back on `_duo`.
  */
 
-program.on('--help', function(){
-  console.log('  Examples:');
-  console.log();
-  console.log('    # build from metalsmith.json:');
-  console.log('    $ metalsmith');
-  console.log();
-  console.log('    # build from lib/config.json:');
-  console.log('    $ metalsmith --config lib/config.json');
-  console.log();
+args.unshift(resolve(__dirname, '_metalsmith'));
+
+/**
+ * Add the necessary node flag.
+ */
+
+if (!require('has-generators')) args.unshift('--harmony-generators');
+
+/**
+ * Spawn.
+ */
+
+var proc = spawn(process.execPath, args, { stdio: 'inherit' });
+
+/**
+ * Exit.
+ */
+
+proc.on('exit', function (code) {
+  process.exit(code);
 });
-
-/**
- * Parse.
- */
-
-program.parse(process.argv);
-
-/**
- * Config.
- */
-
-var dir = process.cwd();
-var config = program.config;
-var path = resolve(dir, config);
-if (!exists(path)) fatal('could not find a ' + config + ' configuration file.');
-
-try {
-  var json = require(path);
-} catch (e) {
-  fatal('it seems like ' + config + ' is malformed.');
-}
-
-/**
- * Metalsmith.
- */
-
-var metalsmith = new Metalsmith(dir);
-if (json.source) metalsmith.source(json.source);
-if (json.destination) metalsmith.destination(json.destination);
-if (json.concurrency) metalsmith.concurrency(json.concurrency);
-if (json.metadata) metalsmith.metadata(json.metadata);
-if (json.clean != null) metalsmith.clean(json.clean);
-
-/**
- * Plugins.
- */
-
-normalize(json.plugins).forEach(function(plugin){
-  for (var name in plugin) {
-    var opts = plugin[name];
-    var mod;
-
-    try {
-      var local = resolve(dir, name);
-      var npm = resolve(dir, 'node_modules', name);
-
-      if (exists(local) || exists(local + '.js')) {
-        mod = require(local);
-      } else if (exists(npm)) {
-        mod = require(npm);
-      } else {
-        mod = require(name);
-      }
-    } catch (e) {
-      fatal('failed to require plugin "' + name + '".');
-    }
-
-    try {
-      metalsmith.use(mod(opts));
-    } catch (e) {
-      fatal('error using plugin "' + name + '"...', e.message + '\n\n' + e.stack);
-    }
-  }
-});
-
-/**
- * Build.
- */
-
-metalsmith.build(function(err){
-  if (err) return fatal(err.message, err.stack);
-  log('successfully built to ' + metalsmith.destination());
-});
-
-/**
- * Log an error and then exit the process.
- *
- * @param {String} msg
- * @param {String} [stack]  Optional stack trace to print.
- */
-
-function fatal(msg, stack){
-  console.error();
-  console.error(chalk.red('  Metalsmith') + chalk.gray(' · ') + msg);
-  if (stack) {
-    console.error();
-    console.error(chalk.gray(stack));
-  }
-  console.error();
-  process.exit(1);
-}
-
-/**
- * Log a `message`.
- *
- * @param {String} message
- */
-
-function log(message){
-  console.log();
-  console.log(chalk.gray('  Metalsmith · ') + message);
-  console.log();
-}
-
-/**
- * Normalize an `obj` of plugins.
- *
- * @param {Array or Object} obj
- * @return {Array}
- */
-
-function normalize(obj){
-  if (obj instanceof Array) return obj;
-  var ret = [];
-
-  for (var key in obj) {
-    var plugin = {};
-    plugin[key] = obj[key];
-    ret.push(plugin);
-  }
-
-  return ret;
-}

--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
 
 /**
- * Add backwards compatibility for Node 0.10.
- */
-
-require('gnode');
-
-/**
  * Export `Metalsmith`.
  */
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "git://github.com/segmentio/metalsmith.git",
   "description": "An extremely simple, pluggable static site generator.",
   "bin": {
-    "metalsmith": "bin/metalsmith"
+    "metalsmith": "bin/metalsmith",
+    "_metalsmith": "bin/_metalsmith"
   },
   "scripts": {
     "test": "make test"
@@ -18,8 +19,8 @@
     "co-fs-extra": "0.0.2",
     "commander": "^2.6.0",
     "fs-extra": "~0.10.0",
-    "gnode": "^0.1.0",
     "gray-matter": "^2.0.0",
+    "has-generators": "^1.0.1",
     "is": "^2.2.0",
     "is-utf8": "~0.2.0",
     "recursive-readdir": "^1.2.1",
@@ -27,11 +28,13 @@
     "stat-mode": "^0.2.0",
     "thunkify": "^2.1.2",
     "unyield": "0.0.1",
-    "ware": "^1.2.0"
+    "ware": "^1.2.0",
+    "win-fork": "^1.1.1"
   },
   "devDependencies": {
     "assert-dir-equal": "~1.0.1",
     "co-mocha": "^1.0.1",
+    "gnode": "^0.1.0",
     "metalsmith-drafts": "0.0.1",
     "metalsmith-markdown": "0.2.1",
     "mocha": "^1.21.4"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gnode": "^0.1.0",
     "metalsmith-drafts": "0.0.1",
     "metalsmith-markdown": "0.2.1",
-    "mocha": "^1.21.4"
+    "mocha": "^2.2.5"
   },
   "keywords": [
     "static",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "gnode": "^0.1.0",
     "metalsmith-drafts": "0.0.1",
     "metalsmith-markdown": "0.2.1",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "semver": "^4.3.4"
   },
   "keywords": [
     "static",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,9 @@
   "devDependencies": {
     "assert-dir-equal": "~1.0.1",
     "co-mocha": "^1.0.1",
-    "gnode": "^0.1.0",
     "metalsmith-drafts": "0.0.1",
     "metalsmith-markdown": "0.2.1",
-    "mocha": "^2.2.5",
-    "semver": "^4.3.4"
+    "mocha": "^2.2.5"
   },
   "keywords": [
     "static",

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,6 @@ var noop = function(){};
 var path = require('path');
 var rm = require('rimraf').sync;
 var fixture = path.resolve.bind(path, __dirname, 'fixtures');
-var semver = require('semver');
 
 describe('Metalsmith', function(){
   beforeEach(function(){
@@ -505,13 +504,11 @@ describe('Metalsmith', function(){
 });
 
 describe('CLI', function(){
-  var cmd = semver.satisfies(process.version, '<= 0.10')
-    ? path.resolve(__dirname, '../node_modules/.bin/gnode') + ' ' + path.resolve(__dirname, '../bin/_metalsmith')
-    : path.resolve(__dirname, '../bin/metalsmith');
+  var bin = path.resolve(__dirname, '../bin/_metalsmith');
 
   describe('build', function(){
     it('should error without a metalsmith.json', function(done){
-      exec(cmd, { cwd: fixture('cli-no-config') }, function(err, stdout){
+      exec(bin, { cwd: fixture('cli-no-config') }, function(err, stdout){
         assert(err);
         assert(~err.message.indexOf('could not find a metalsmith.json configuration file.'));
         done();
@@ -519,7 +516,7 @@ describe('CLI', function(){
     });
 
     it('should grab config from metalsmith.json', function(done){
-      exec(cmd, { cwd: fixture('cli-json') }, function(err, stdout){
+      exec(bin, { cwd: fixture('cli-json') }, function(err, stdout){
         if (err) return done(err);
         equal(fixture('cli-json/destination'), fixture('cli-json/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -529,7 +526,7 @@ describe('CLI', function(){
     });
 
     it('should grab config from a config.json', function(done){
-      exec(cmd + ' -c config.json', { cwd: fixture('cli-other-config') }, function(err, stdout){
+      exec(bin + ' -c config.json', { cwd: fixture('cli-other-config') }, function(err, stdout){
         if (err) return done(err);
         equal(fixture('cli-other-config/destination'), fixture('cli-other-config/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -539,7 +536,7 @@ describe('CLI', function(){
     });
 
     it('should require a plugin', function(done){
-      exec(cmd, { cwd: fixture('cli-plugin-object') }, function(err, stdout, stderr){
+      exec(bin, { cwd: fixture('cli-plugin-object') }, function(err, stdout, stderr){
         if (err) return done(err);
         equal(fixture('cli-plugin-object/build'), fixture('cli-plugin-object/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -549,7 +546,7 @@ describe('CLI', function(){
     });
 
     it('should require plugins as an array', function(done){
-      exec(cmd, { cwd: fixture('cli-plugin-array') }, function(err, stdout){
+      exec(bin, { cwd: fixture('cli-plugin-array') }, function(err, stdout){
         if (err) return done(err);
         equal(fixture('cli-plugin-array/build'), fixture('cli-plugin-array/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -559,7 +556,7 @@ describe('CLI', function(){
     });
 
     it('should error when failing to require a plugin', function(done){
-      exec(cmd, { cwd: fixture('cli-no-plugin') }, function(err){
+      exec(bin, { cwd: fixture('cli-no-plugin') }, function(err){
         assert(err);
         assert(~err.message.indexOf('failed to require plugin "metalsmith-non-existant".'));
         done();
@@ -567,7 +564,7 @@ describe('CLI', function(){
     });
 
     it('should error when failing to use a plugin', function(done){
-      exec(cmd, { cwd: fixture('cli-broken-plugin') }, function(err){
+      exec(bin, { cwd: fixture('cli-broken-plugin') }, function(err){
         assert(err);
         assert(~err.message.indexOf('error using plugin "./plugin"...'));
         assert(~err.message.indexOf('Break!'));
@@ -577,7 +574,7 @@ describe('CLI', function(){
     });
 
     it('should allow requiring a local plugin', function(done){
-      exec(cmd, { cwd: fixture('cli-plugin-local') }, function(err, stdout, stderr){
+      exec(bin, { cwd: fixture('cli-plugin-local') }, function(err, stdout, stderr){
         equal(fixture('cli-plugin-local/build'), fixture('cli-plugin-local/expected'));
         assert(~stdout.indexOf('successfully built to '));
         assert(~stdout.indexOf(fixture('cli-plugin-local/build')));

--- a/test/index.js
+++ b/test/index.js
@@ -504,7 +504,7 @@ describe('Metalsmith', function(){
 });
 
 describe('CLI', function(){
-  var bin = path.resolve(__dirname, '../bin/_metalsmith');
+  var bin = path.resolve(__dirname, '../bin/metalsmith');
 
   describe('build', function(){
     it('should error without a metalsmith.json', function(done){

--- a/test/index.js
+++ b/test/index.js
@@ -310,11 +310,11 @@ describe('Metalsmith', function(){
     });
 
     it('should ignore the files specified in ignores', function(done){
+      var stats = fs.statSync(path.join(__dirname, 'fixtures/basic/src/index.md'));
       var m = Metalsmith('test/fixtures/basic');
       m.ignore('nested');
       m.read(function(err, files){
         if (err) return done(err);
-        stats = fs.statSync(path.join(__dirname, 'fixtures/basic/src/index.md'));
         assert.deepEqual(files, {
           'index.md': {
             date: new Date('2013-12-02'),

--- a/test/index.js
+++ b/test/index.js
@@ -505,7 +505,7 @@ describe('Metalsmith', function(){
 });
 
 describe('CLI', function(){
-  var bin = path.resolve(__dirname, '../bin/metalsmith');
+  var bin = path.resolve(__dirname, '../bin/_metalsmith');
 
   var cmd = semver.satisfies(process.version, '<= 0.10')
     ? path.resolve(__dirname, '../node_modules/.bin/gnode') + ' ' + bin
@@ -513,7 +513,7 @@ describe('CLI', function(){
 
   describe('build', function(){
     it('should error without a metalsmith.json', function(done){
-      exec(bin, { cwd: fixture('cli-no-config') }, function(err, stdout){
+      exec(cmd, { cwd: fixture('cli-no-config') }, function(err, stdout){
         assert(err);
         assert(~err.message.indexOf('could not find a metalsmith.json configuration file.'));
         done();
@@ -521,7 +521,7 @@ describe('CLI', function(){
     });
 
     it('should grab config from metalsmith.json', function(done){
-      exec(bin, { cwd: fixture('cli-json') }, function(err, stdout){
+      exec(cmd, { cwd: fixture('cli-json') }, function(err, stdout){
         if (err) return done(err);
         equal(fixture('cli-json/destination'), fixture('cli-json/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -531,7 +531,7 @@ describe('CLI', function(){
     });
 
     it('should grab config from a config.json', function(done){
-      exec(bin + ' -c config.json', { cwd: fixture('cli-other-config') }, function(err, stdout){
+      exec(cmd + ' -c config.json', { cwd: fixture('cli-other-config') }, function(err, stdout){
         if (err) return done(err);
         equal(fixture('cli-other-config/destination'), fixture('cli-other-config/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -541,7 +541,7 @@ describe('CLI', function(){
     });
 
     it('should require a plugin', function(done){
-      exec(bin, { cwd: fixture('cli-plugin-object') }, function(err, stdout, stderr){
+      exec(cmd, { cwd: fixture('cli-plugin-object') }, function(err, stdout, stderr){
         if (err) return done(err);
         equal(fixture('cli-plugin-object/build'), fixture('cli-plugin-object/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -551,7 +551,7 @@ describe('CLI', function(){
     });
 
     it('should require plugins as an array', function(done){
-      exec(bin, { cwd: fixture('cli-plugin-array') }, function(err, stdout){
+      exec(cmd, { cwd: fixture('cli-plugin-array') }, function(err, stdout){
         if (err) return done(err);
         equal(fixture('cli-plugin-array/build'), fixture('cli-plugin-array/expected'));
         assert(~stdout.indexOf('successfully built to '));
@@ -561,7 +561,7 @@ describe('CLI', function(){
     });
 
     it('should error when failing to require a plugin', function(done){
-      exec(bin, { cwd: fixture('cli-no-plugin') }, function(err){
+      exec(cmd, { cwd: fixture('cli-no-plugin') }, function(err){
         assert(err);
         assert(~err.message.indexOf('failed to require plugin "metalsmith-non-existant".'));
         done();
@@ -569,7 +569,7 @@ describe('CLI', function(){
     });
 
     it('should error when failing to use a plugin', function(done){
-      exec(bin, { cwd: fixture('cli-broken-plugin') }, function(err){
+      exec(cmd, { cwd: fixture('cli-broken-plugin') }, function(err){
         assert(err);
         assert(~err.message.indexOf('error using plugin "./plugin"...'));
         assert(~err.message.indexOf('Break!'));
@@ -579,7 +579,7 @@ describe('CLI', function(){
     });
 
     it('should allow requiring a local plugin', function(done){
-      exec(bin, { cwd: fixture('cli-plugin-local') }, function(err, stdout, stderr){
+      exec(cmd, { cwd: fixture('cli-plugin-local') }, function(err, stdout, stderr){
         equal(fixture('cli-plugin-local/build'), fixture('cli-plugin-local/expected'));
         assert(~stdout.indexOf('successfully built to '));
         assert(~stdout.indexOf(fixture('cli-plugin-local/build')));

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ var noop = function(){};
 var path = require('path');
 var rm = require('rimraf').sync;
 var fixture = path.resolve.bind(path, __dirname, 'fixtures');
+var semver = require('semver');
 
 describe('Metalsmith', function(){
   beforeEach(function(){
@@ -505,6 +506,10 @@ describe('Metalsmith', function(){
 
 describe('CLI', function(){
   var bin = path.resolve(__dirname, '../bin/metalsmith');
+
+  var cmd = semver.satisfies(process.version, '<= 0.10')
+    ? path.resolve(__dirname, '../node_modules/.bin/gnode') + ' ' + bin
+    : bin;
 
   describe('build', function(){
     it('should error without a metalsmith.json', function(done){

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --reporter spec
---require gnode
 --require co-mocha
 --slow 500
 --bail

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --reporter spec
+--require gnode
 --require co-mocha
 --slow 500
 --bail


### PR DESCRIPTION
This fixes #132 by adding a separate `_metalsmith` bin that is doing the actual processing. The `metalsmith` bin is now a proxy that simply adds the `--harmony-generators` flag when needed.

Node 0.10 users will need to use gnode, babel or similar in order to continue using metalsmith, but the trade-off is now that node 0.11, 0.12 and iojs will work out of the box. (and it's future-proof)

This also allows users with gnode/babel/etc in their toolchain to use it with metalsmith as well.

/cc @ianstormtaylor @MoOx 