### PR TITLE
Default callback for Metalsmith.build()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,17 +186,24 @@ Metalsmith.prototype.path = function(){
  *
  * @return {Object}
  */
-
-Metalsmith.prototype.build = unyield(function*(){
-  var clean = this.clean();
-  var dest = this.destination();
-  if (clean) yield rm(dest);
-
-  var files = yield this.read();
-  files = yield this.run(files);
-  yield this.write(files);
-  return files;
-});
+Metalsmith.prototype.build = function(cb) {
+  var unyielder = unyield(function*(){
+    var clean = this.clean();
+    var dest = this.destination();
+    if (clean) yield rm(dest);
+  
+    var files = yield this.read();
+    files = yield this.run(files);
+    yield this.write(files);
+    return files;
+  });
+  if(typeof cb !== 'function') {
+    cb = function(err, files) {
+      if (err) { throw err; }
+    };
+  }
+  return unyielder(cb);
+};
 
 /**
  * Run a set of `files` through the plugins stack.

--- a/lib/index.js
+++ b/lib/index.js
@@ -187,13 +187,14 @@ Metalsmith.prototype.path = function(){
  * @return {Object}
  */
 Metalsmith.prototype.build = function(cb) {
+	var that = this;
   var unyielder = unyield(function*(){
-    var clean = this.clean();
-    var dest = this.destination();
+    var clean = that.clean();
+    var dest = that.destination();
     if (clean) yield rm(dest);
   
-    var files = yield this.read();
-    files = yield this.run(files);
+    var files = yield that.read();
+    files = yield that.run(files);
     yield this.write(files);
     return files;
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,7 @@ Metalsmith.prototype.build = function(cb) {
   
     var files = yield that.read();
     files = yield that.run(files);
-    yield this.write(files);
+    yield that.write(files);
     return files;
   });
   if(typeof cb !== 'function') {


### PR DESCRIPTION
Someone smarter than me might be able to come up with a more elegant solution than mine, I've give what I have.  The build function only works if you pass it a callback, which is somewhat unintuitive.  This change accepts your callback, but if you don't provide one, it inserts a default callback which simply throws any errors returned.

Generators are a new thing for me, and I feel like my changes are tacky and ugly, defacing some very elegant code.  However, in my tests, they do seem to work, which is more important than elegance.  If anyone has a way to improve this and provide the same functionality with more elegance, I'll be your biggest fan.