### PR TITLE
Add Node 4.0 to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.12"
   - "iojs"
+  - "4.0"


### PR DESCRIPTION
NodeJS 4.0 is out. Let's see if it works!