### PR TITLE
Add `file` key to the files hash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -284,6 +284,7 @@ Metalsmith.prototype.readFile = unyield(function*(file){
 
     ret.mode = Mode(stats).toOctal();
     ret.stats = stats;
+    ret.file = file;
   } catch (e) {
     if (e.code == 'invalid_frontmatter') throw e;
     e.message = 'Failed to read the file at: ' + file + '\n\n' + e.message;

--- a/test/index.js
+++ b/test/index.js
@@ -239,7 +239,8 @@ describe('Metalsmith', function(){
             title: 'A Title',
             contents: new Buffer('body'),
             mode: stats.mode.toString(8).slice(-4),
-            stats: stats
+            stats: stats,
+            file: fixture('read/src/index.md')
           }
         });
         done();
@@ -257,7 +258,8 @@ describe('Metalsmith', function(){
             title: 'A Title',
             contents: new Buffer('body'),
             mode: stats.mode.toString(8).slice(-4),
-            stats: stats
+            stats: stats,
+            file: fixture('read-dir/dir/index.md')
           }
         });
         done();
@@ -273,7 +275,8 @@ describe('Metalsmith', function(){
           'bin': {
             contents: new Buffer('echo test'),
             mode: stats.mode.toString(8).slice(-4),
-            stats: stats
+            stats: stats,
+            file: fixture('read-mode/src/bin')
           }
         });
         done();
@@ -310,7 +313,7 @@ describe('Metalsmith', function(){
     });
 
     it('should ignore the files specified in ignores', function(done){
-      var stats = fs.statSync(path.join(__dirname, 'fixtures/basic/src/index.md'));
+      var stats = fs.statSync(fixture('basic/src/index.md'));
       var m = Metalsmith('test/fixtures/basic');
       m.ignore('nested');
       m.read(function(err, files){
@@ -321,7 +324,8 @@ describe('Metalsmith', function(){
             title: 'A Title',
             contents: new Buffer('body'),
             mode: stats.mode.toString(8).slice(-4),
-            stats: stats
+            stats: stats,
+            file: fixture('basic/src/index.md')
           }
         });
         done();


### PR DESCRIPTION
For a plugin I'm working on, it would be great to have access to the original filename on the files that come back. We only get the `stat` object, which can't trace back the original filename.