### PR TITLE
Use appropriate dependency for handlebars template

### DIFF
--- a/examples/static-site/package.json
+++ b/examples/static-site/package.json
@@ -2,7 +2,7 @@
   "name": "static-site-example",
   "private": true,
   "dependencies": {
-    "handlebars": "^4.0.5",
+    "jstransformer-handlebars": "^1.1.0",
     "metalsmith": "^2.1.0",
     "metalsmith-layouts": "^1.4.1",
     "metalsmith-markdown": "^0.2.1",


### PR DESCRIPTION
When using `metalsmith-layouts` using the handlebars engine and with `handlebars` installed, I get this error:

```
Error: no files to process. See https://www.npmjs.com/package/metalsmith-layouts#no-files-to-process
    at Ware.<anonymous> (/Users/davidharting/repos/metalsmith-trial/node_modules/metalsmith-layouts/lib/index.js:141:7)
    at Ware.<anonymous> (/Users/davidharting/repos/metalsmith-trial/node_modules/wrap-fn/index.js:45:19)
    at Immediate.next (/Users/davidharting/repos/metalsmith-trial/node_modules/ware/lib/index.js:85:20)
    at Immediate._onImmediate (/Users/davidharting/repos/metalsmith-trial/node_modules/wrap-fn/index.js:121:18)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5)
```

The [`metalsmith-layouts` docs](https://github.com/metalsmith/metalsmith-layouts#example) indicate that you should install `jstransformer-handlebars` instead of regular `handlebars`.

Installing `jstransformer-handlebars` solved my issue and I can build using handlebars layouts. I uninstalled `handlebars` and continue to have good builds.